### PR TITLE
npm/npmjs/-/pako/2.1.0

### DIFF
--- a/curations/npm/npmjs/-/pako.yaml
+++ b/curations/npm/npmjs/-/pako.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pako
+  provider: npmjs
+  type: npm
+revisions:
+  2.1.0:
+    licensed:
+      declared: any-OSI-perl-modules


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npm/npmjs/-/pako/2.1.0

**Details:**
Add any-OSI-perl-modules license declaration

**Resolution:**
Curating license based on package.json

**Affected definitions**:
- [pako 2.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/pako/2.1.0)